### PR TITLE
Switch product to custom subcategory model

### DIFF
--- a/asoud-main/apps/product/admin.py
+++ b/asoud-main/apps/product/admin.py
@@ -48,7 +48,7 @@ class ProductAdmin(BaseAdmin):
         'name',
         'description',
         'technical_detail',
-        'sub_category',
+        'product_sub_category',
         'keywords',
         'stock',
         'main_price',

--- a/asoud-main/apps/product/migrations/0001_product_subcategory.py
+++ b/asoud-main/apps/product/migrations/0001_product_subcategory.py
@@ -1,0 +1,39 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import uuid
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        # Define dependencies if initial migrations exist
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ProductSubCategory',
+            fields=[
+                ('id', models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)),
+                ('created_at', models.DateTimeField(auto_now_add=True, blank=True, null=True)),
+                ('updated_at', models.DateTimeField(auto_now=True, blank=True, null=True)),
+                ('market', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='market.market', verbose_name='Market')),
+                ('sub_category', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='category.subcategory', verbose_name='Sub Category')),
+            ],
+            options={
+                'db_table': 'product_sub_category',
+                'verbose_name': 'Product sub category',
+                'verbose_name_plural': 'Product sub categories',
+                'unique_together': {('market', 'sub_category')},
+            },
+        ),
+        migrations.RemoveField(
+            model_name='product',
+            name='sub_category',
+        ),
+        migrations.AddField(
+            model_name='product',
+            name='product_sub_category',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='product.productsubcategory', verbose_name='Product sub category', null=True),
+        ),
+    ]

--- a/asoud-main/apps/product/models.py
+++ b/asoud-main/apps/product/models.py
@@ -49,6 +49,28 @@ class ProductTheme(BaseModel):
         return self.name
 
 
+class ProductSubCategory(BaseModel):
+    market = models.ForeignKey(
+        Market,
+        on_delete=models.CASCADE,
+        verbose_name=_('Market'),
+    )
+    sub_category = models.ForeignKey(
+        SubCategory,
+        on_delete=models.CASCADE,
+        verbose_name=_('Sub Category'),
+    )
+
+    class Meta:
+        db_table = 'product_sub_category'
+        verbose_name = _('Product sub category')
+        verbose_name_plural = _('Product sub categories')
+        unique_together = ('market', 'sub_category')
+
+    def __str__(self):
+        return f"{self.market} - {self.sub_category}"
+
+
 class Product(BaseModel):
     GOOD = "good"
     SERVICE = "service"
@@ -147,10 +169,10 @@ class Product(BaseModel):
         verbose_name=_('Technical detail'),
     )
 
-    sub_category = models.ForeignKey(
-        SubCategory,
+    product_sub_category = models.ForeignKey(
+        ProductSubCategory,
         on_delete=models.CASCADE,
-        verbose_name=_('Category'),
+        verbose_name=_('Product sub category'),
     )
 
     keywords = models.ManyToManyField(

--- a/asoud-main/apps/product/serializers/owner_serializers.py
+++ b/asoud-main/apps/product/serializers/owner_serializers.py
@@ -8,6 +8,7 @@ from apps.product.models import (
     ProductTheme,
     ProductKeyword,
     ProductImage,
+    ProductSubCategory,
 )
 
 class KeywordField(serializers.RelatedField):
@@ -79,7 +80,7 @@ class ProductCreateSerializer(serializers.ModelSerializer):
             'name',
             'description',
             'technical_detail',
-            'sub_category',
+            'product_sub_category',
             'keywords',
             'stock',
             'main_price',


### PR DESCRIPTION
## Summary
- add `ProductSubCategory` model
- reference new model from `Product`
- update owner serializers and admin to use new field
- add initial migration for new model

## Testing
- `python manage.py makemigrations --check --dry-run` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684183ca45e4832a8eb4b97fbcce5af4