### PR TITLE
Implement product category hierarchy APIs

### DIFF
--- a/asoud-main/README.md
+++ b/asoud-main/README.md
@@ -75,3 +75,13 @@ To set up the Project, follow these steps:
         docker-compose -f docker-compose.prod.yaml build
         docker-compose -f docker-compose.prod.yaml up -d
         ```
+
+## Product Category API Endpoints
+
+These endpoints provide hierarchical product categories tied to a job subcategory.
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/v1/product/category/group/list/<sub_category_id>/` | List product category groups for a subcategory |
+| GET | `/api/v1/product/category/list/<group_id>/` | List product categories within a group |
+| GET | `/api/v1/product/category/sub/list/<category_id>/` | List product subcategories within a category |

--- a/asoud-main/apps/product/models.py
+++ b/asoud-main/apps/product/models.py
@@ -7,6 +7,66 @@ from apps.market.models import Market
 from apps.comment.models import Comment
 from apps.category.models import SubCategory
 
+
+class ProductCategoryGroup(BaseModel):
+    sub_category = models.ForeignKey(
+        SubCategory,
+        on_delete=models.CASCADE,
+        verbose_name=_('Sub Category'),
+    )
+    title = models.CharField(
+        max_length=255,
+        verbose_name=_('Title'),
+    )
+
+    class Meta:
+        db_table = 'product_category_group'
+        verbose_name = _('Product category group')
+        verbose_name_plural = _('Product category groups')
+
+    def __str__(self):
+        return self.title
+
+
+class ProductCategory(BaseModel):
+    group = models.ForeignKey(
+        ProductCategoryGroup,
+        on_delete=models.CASCADE,
+        verbose_name=_('Group'),
+    )
+    title = models.CharField(
+        max_length=255,
+        verbose_name=_('Title'),
+    )
+
+    class Meta:
+        db_table = 'product_category'
+        verbose_name = _('Product category')
+        verbose_name_plural = _('Product categories')
+
+    def __str__(self):
+        return self.title
+
+
+class ProductSubCategory(BaseModel):
+    category = models.ForeignKey(
+        ProductCategory,
+        on_delete=models.CASCADE,
+        verbose_name=_('Category'),
+    )
+    title = models.CharField(
+        max_length=255,
+        verbose_name=_('Title'),
+    )
+
+    class Meta:
+        db_table = 'product_sub_category'
+        verbose_name = _('Product sub category')
+        verbose_name_plural = _('Product sub categories')
+
+    def __str__(self):
+        return self.title
+
 # Create your models here.
 
 

--- a/asoud-main/apps/product/serializers/category_serializers.py
+++ b/asoud-main/apps/product/serializers/category_serializers.py
@@ -1,0 +1,34 @@
+from rest_framework import serializers
+
+from apps.product.models import (
+    ProductCategoryGroup,
+    ProductCategory,
+    ProductSubCategory,
+)
+
+
+class ProductCategoryGroupSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProductCategoryGroup
+        fields = [
+            'id',
+            'title',
+        ]
+
+
+class ProductCategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProductCategory
+        fields = [
+            'id',
+            'title',
+        ]
+
+
+class ProductSubCategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProductSubCategory
+        fields = [
+            'id',
+            'title',
+        ]

--- a/asoud-main/apps/product/urls/category_urls.py
+++ b/asoud-main/apps/product/urls/category_urls.py
@@ -1,0 +1,27 @@
+from django.urls import path
+
+from apps.product.views.category_views import (
+    ProductCategoryGroupListAPIView,
+    ProductCategoryListAPIView,
+    ProductSubCategoryListAPIView,
+)
+
+app_name = 'product_category'
+
+urlpatterns = [
+    path(
+        'group/list/<str:pk>/',
+        ProductCategoryGroupListAPIView.as_view(),
+        name='group-list',
+    ),
+    path(
+        'list/<str:pk>/',
+        ProductCategoryListAPIView.as_view(),
+        name='category-list',
+    ),
+    path(
+        'sub/list/<str:pk>/',
+        ProductSubCategoryListAPIView.as_view(),
+        name='sub-category-list',
+    ),
+]

--- a/asoud-main/apps/product/views/category_views.py
+++ b/asoud-main/apps/product/views/category_views.py
@@ -1,0 +1,109 @@
+from rest_framework import views
+from rest_framework.response import Response
+
+from utils.response import ApiResponse
+
+from apps.product.models import (
+    ProductCategoryGroup,
+    ProductCategory,
+    ProductSubCategory,
+)
+from apps.product.serializers.category_serializers import (
+    ProductCategoryGroupSerializer,
+    ProductCategorySerializer,
+    ProductSubCategorySerializer,
+)
+from apps.category.models import SubCategory
+
+
+class ProductCategoryGroupListAPIView(views.APIView):
+    def get(self, request, pk, format=None):
+        try:
+            sub_category = SubCategory.objects.get(id=pk)
+        except SubCategory.DoesNotExist:
+            return Response(
+                ApiResponse(
+                    success=False,
+                    code=404,
+                    error="Sub Category Not Found",
+                )
+            )
+
+        group_list = ProductCategoryGroup.objects.filter(sub_category=sub_category)
+
+        serializer = ProductCategoryGroupSerializer(
+            group_list,
+            many=True,
+            context={"request": request},
+        )
+
+        success_response = ApiResponse(
+            success=True,
+            code=200,
+            data=serializer.data,
+            message='Data retrieved successfully',
+        )
+
+        return Response(success_response)
+
+
+class ProductCategoryListAPIView(views.APIView):
+    def get(self, request, pk, format=None):
+        try:
+            group_obj = ProductCategoryGroup.objects.get(id=pk)
+        except ProductCategoryGroup.DoesNotExist:
+            return Response(
+                ApiResponse(
+                    success=False,
+                    code=404,
+                    error="Product Category Group Not Found",
+                )
+            )
+
+        category_list = ProductCategory.objects.filter(group=group_obj)
+
+        serializer = ProductCategorySerializer(
+            category_list,
+            many=True,
+            context={"request": request},
+        )
+
+        success_response = ApiResponse(
+            success=True,
+            code=200,
+            data=serializer.data,
+            message='Data retrieved successfully',
+        )
+
+        return Response(success_response)
+
+
+class ProductSubCategoryListAPIView(views.APIView):
+    def get(self, request, pk, format=None):
+        try:
+            category_obj = ProductCategory.objects.get(id=pk)
+        except ProductCategory.DoesNotExist:
+            return Response(
+                ApiResponse(
+                    success=False,
+                    code=404,
+                    error="Product Category Not Found",
+                )
+            )
+
+        sub_category_list = ProductSubCategory.objects.filter(category=category_obj)
+
+        serializer = ProductSubCategorySerializer(
+            sub_category_list,
+            many=True,
+            context={"request": request},
+        )
+
+        success_response = ApiResponse(
+            success=True,
+            code=200,
+            data=serializer.data,
+            message='Data retrieved successfully',
+        )
+
+        return Response(success_response)

--- a/asoud-main/config/urls.py
+++ b/asoud-main/config/urls.py
@@ -54,6 +54,10 @@ urlpatterns = [
         include('apps.product.urls.owner_urls'),
     ),
     path(
+        'api/v1/product/category/',
+        include('apps.product.urls.category_urls'),
+    ),
+    path(
         'api/v1/user/chat/',
         include('apps.chat.urls.user_urls'),
     ),


### PR DESCRIPTION
## Summary
- add ProductCategoryGroup, ProductCategory and ProductSubCategory models
- implement serializers and API views for listing the hierarchy
- register URLs for new product category endpoints
- document the new API endpoints in README

## Testing
- `python -m py_compile asoud-main/apps/product/models.py asoud-main/apps/product/serializers/category_serializers.py asoud-main/apps/product/views/category_views.py asoud-main/apps/product/urls/category_urls.py asoud-main/config/urls.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684183ef5180832aaa75ac4dec2ee308