### PR TITLE
Fix user profile __str__ methods

### DIFF
--- a/asoud-main/apps/users/models.py
+++ b/asoud-main/apps/users/models.py
@@ -96,7 +96,7 @@ class UserProfile(BaseModel):
         verbose_name_plural = _('User profiles')
 
     def __str__(self):
-        return self.mobile_number
+        return self.user.mobile_number
 
 
 class UserDocument(BaseModel):
@@ -118,7 +118,7 @@ class UserDocument(BaseModel):
         verbose_name_plural = _('User documents')
 
     def __str__(self):
-        return self.user
+        return self.user.mobile_number
 
 
 class UserColleague(BaseModel):
@@ -139,4 +139,4 @@ class UserColleague(BaseModel):
         verbose_name_plural = _('User colleagues')
 
     def __str__(self):
-        return self.user
+        return self.user.mobile_number


### PR DESCRIPTION
## Summary
- fix `__str__` implementation of `UserProfile`
- fix `__str__` implementation of `UserDocument`
- fix `__str__` implementation of `UserColleague`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68418662d4e4832aa1cff5e1b92eb226