### PR TITLE
Remove unused tests modules

### DIFF
--- a/asoud-main/apps/advertise/tests.py
+++ b/asoud-main/apps/advertise/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/affiliate/tests.py
+++ b/asoud-main/apps/affiliate/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/discount/tests.py
+++ b/asoud-main/apps/discount/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/flutter/tests.py
+++ b/asoud-main/apps/flutter/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/market_subdomain/tests.py
+++ b/asoud-main/apps/market_subdomain/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/notification/tests.py
+++ b/asoud-main/apps/notification/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/payment/tests.py
+++ b/asoud-main/apps/payment/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/price_inquiry/tests.py
+++ b/asoud-main/apps/price_inquiry/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/referral/tests.py
+++ b/asoud-main/apps/referral/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/reserve/tests.py
+++ b/asoud-main/apps/reserve/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/sms/tests.py
+++ b/asoud-main/apps/sms/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/asoud-main/apps/wallet/tests.py
+++ b/asoud-main/apps/wallet/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.


### PR DESCRIPTION
## Summary
- drop empty `tests.py` modules from all apps

## Testing
- `python manage.py test --keepdb` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841864dace0832ab02637cf0e174573